### PR TITLE
accel/mshv: Refactor arch specific code from common code

### DIFF
--- a/accel/mshv/mshv-all.c
+++ b/accel/mshv/mshv-all.c
@@ -154,10 +154,11 @@ static int set_synthetic_proc_features(int vm_fd)
     features.access_intr_ctrl_regs = 1;
     features.access_vp_index = 1;
     features.access_hypercall_regs = 1;
-    features.access_guest_idle_reg = 1;
     features.tb_flush_hypercalls = 1;
     features.synthetic_cluster_ipi = 1;
     features.direct_synthetic_timers = 1;
+
+    mshv_arch_amend_proc_features(&features);
 
     in.property_code = HV_PARTITION_PROPERTY_SYNTHETIC_PROC_FEATURES;
     in.property_value = features.as_uint64[0];

--- a/include/system/mshv.h
+++ b/include/system/mshv.h
@@ -95,6 +95,7 @@ extern MshvState *mshv_state;
 
 struct AccelCPUState {
   int cpufd;
+  bool dirty;
 };
 
 typedef struct MshvMsiControl {

--- a/include/system/mshv.h
+++ b/include/system/mshv.h
@@ -188,6 +188,8 @@ int mshv_set_generic_regs(int cpu_fd, hv_register_assoc *assocs, size_t n_regs);
 int mshv_arch_put_registers(const CPUState *cpu);
 void mshv_arch_init_vcpu(CPUState *cpu);
 void mshv_arch_destroy_vcpu(CPUState *cpu);
+void mshv_arch_amend_proc_features(
+    union hv_partition_synthetic_processor_features *features);
 
 /* pio */
 int mshv_pio_write(uint64_t port, const uint8_t *data, uintptr_t size,

--- a/include/system/mshv.h
+++ b/include/system/mshv.h
@@ -190,6 +190,7 @@ void mshv_arch_init_vcpu(CPUState *cpu);
 void mshv_arch_destroy_vcpu(CPUState *cpu);
 void mshv_arch_amend_proc_features(
     union hv_partition_synthetic_processor_features *features);
+int mshv_arch_post_init_vm(int vm_fd);
 
 /* pio */
 int mshv_pio_write(uint64_t port, const uint8_t *data, uintptr_t size,

--- a/include/system/mshv.h
+++ b/include/system/mshv.h
@@ -6,6 +6,7 @@
  * Authors:
  *  Ziqiao Zhou       <ziqiaozhou@microsoft.com>
  *  Magnus Kulke      <magnuskulke@microsoft.com>
+ *  Jinank Jain       <jinankjain@microsoft.com>
  *
  * This work is licensed under the terms of the GNU GPL, version 2 or later.
  * See the COPYING file in the top-level directory.
@@ -185,6 +186,8 @@ int mshv_load_regs(CPUState *cpu);
 int mshv_store_regs(CPUState *cpu);
 int mshv_set_generic_regs(int cpu_fd, hv_register_assoc *assocs, size_t n_regs);
 int mshv_arch_put_registers(const CPUState *cpu);
+void mshv_arch_init_vcpu(CPUState *cpu);
+void mshv_arch_destroy_vcpu(CPUState *cpu);
 
 /* pio */
 int mshv_pio_write(uint64_t port, const uint8_t *data, uintptr_t size,

--- a/target/i386/mshv/mshv-cpu.c
+++ b/target/i386/mshv/mshv-cpu.c
@@ -1701,3 +1701,9 @@ void mshv_arch_destroy_vcpu(CPUState *cpu)
     g_free(env->emu_mmio_buf);
     env->emu_mmio_buf = NULL;
 }
+
+void mshv_arch_amend_proc_features(
+    union hv_partition_synthetic_processor_features *features)
+{
+    features->access_guest_idle_reg = 1;
+}

--- a/target/i386/mshv/mshv-cpu.c
+++ b/target/i386/mshv/mshv-cpu.c
@@ -6,6 +6,7 @@
  * Authors:
  *  Ziqiao Zhou       <ziqiaozhou@microsoft.com>
  *  Magnus Kulke      <magnuskulke@microsoft.com>
+ *  Jinank Jain       <jinankjain@microsoft.com>
  *
  * This work is licensed under the terms of the GNU GPL, version 2 or later.
  * See the COPYING file in the top-level directory.
@@ -1682,4 +1683,21 @@ int mshv_arch_put_registers(const CPUState *cpu)
     }
 
     return 0;
+}
+
+void mshv_arch_init_vcpu(CPUState *cpu)
+{
+    X86CPU *x86_cpu = X86_CPU(cpu);
+    CPUX86State *env = &x86_cpu->env;
+
+    env->emu_mmio_buf = g_new(char, 4096);
+}
+
+void mshv_arch_destroy_vcpu(CPUState *cpu)
+{
+    X86CPU *x86_cpu = X86_CPU(cpu);
+    CPUX86State *env = &x86_cpu->env;
+
+    g_free(env->emu_mmio_buf);
+    env->emu_mmio_buf = NULL;
 }

--- a/target/i386/mshv/mshv-cpu.c
+++ b/target/i386/mshv/mshv-cpu.c
@@ -1418,6 +1418,8 @@ static int handle_pio_str(CPUState *cpu,
         return -1;
     }
 
+    cpu->accel->dirty = false;
+
     return 0;
 }
 
@@ -1481,6 +1483,8 @@ static int handle_pio_non_str(const CPUState *cpu,
         error_report("Failed to set x64 registers");
         return -1;
     }
+
+    cpu->accel->dirty = false;
 
     return 0;
 }

--- a/target/i386/mshv/mshv-cpu.c
+++ b/target/i386/mshv/mshv-cpu.c
@@ -30,6 +30,9 @@
 #include "trace-accel_mshv.h"
 #include "trace.h"
 
+#include "hw/hyperv/hvhdk_mini.h"
+#include "hw/hyperv/hvgdk.h"
+
 #define MSR_ENTRIES_COUNT 64
 
 static QemuMutex *cpu_guards_lock;
@@ -1706,4 +1709,44 @@ void mshv_arch_amend_proc_features(
     union hv_partition_synthetic_processor_features *features)
 {
     features->access_guest_idle_reg = 1;
+}
+
+/*
+ * Default Microsoft Hypervisor behavior for unimplemented MSR is to send a
+ * fault to the guest if it tries to access it. It is possible to override
+ * this behavior with a more suitable option i.e., ignore writes from the guest
+ * and return zero in attempt to read unimplemented.
+ */
+static int set_unimplemented_msr_action(int vm_fd)
+{
+    struct hv_input_set_partition_property in = {0};
+    struct mshv_root_hvcall args = {0};
+
+    in.property_code  = HV_PARTITION_PROPERTY_UNIMPLEMENTED_MSR_ACTION;
+    in.property_value = HV_UNIMPLEMENTED_MSR_ACTION_IGNORE_WRITE_READ_ZERO;
+
+    args.code   = HVCALL_SET_PARTITION_PROPERTY;
+    args.in_sz  = sizeof(in);
+    args.in_ptr = (uint64_t)&in;
+
+    trace_mshv_hvcall_args("unimplemented_msr_action", args.code, args.in_sz);
+
+    int ret = mshv_hvcall(vm_fd, &args);
+    if (ret < 0) {
+        error_report("Failed to set unimplemented MSR action");
+        return -1;
+    }
+    return 0;
+}
+
+int mshv_arch_post_init_vm(int vm_fd)
+{
+    int ret;
+
+    ret = set_unimplemented_msr_action(vm_fd);
+    if (ret < 0) {
+        error_report("Failed to set unimplemented MSR action");
+    }
+
+    return ret;
 }


### PR DESCRIPTION
Currently x86 specific data structures are used in the common accelartor code while creating and destroying vcpus. Create arch specific helper function to be called from common code.